### PR TITLE
Implement attachment logic for frontend

### DIFF
--- a/src/Modifiers/Invoice/AddInvoiceAttachments.php
+++ b/src/Modifiers/Invoice/AddInvoiceAttachments.php
@@ -54,7 +54,9 @@ class AddInvoiceAttachments extends AbstractModifier
                     }
 
                     $orderAttachment->setFileName($attachment->getName())
-                        ->setFileContent($attachment->getFileData());
+                        ->setFileContent(
+                            base64_decode($attachment->getFileData(), true)
+                        );
 
                     return $orderAttachment;
                 },

--- a/src/Modifiers/Order/AddOrderAttachments.php
+++ b/src/Modifiers/Order/AddOrderAttachments.php
@@ -55,7 +55,9 @@ class AddOrderAttachments extends AbstractModifier
                     }
 
                     $orderAttachment->setFileName($attachment->getName())
-                        ->setFileContent($attachment->getFileData());
+                        ->setFileContent(
+                            base64_decode($attachment->getFileData(), true)
+                        );
 
                     return $orderAttachment;
                 },

--- a/src/Plugin/Controller/Sales/Order/PrintAction/DownloadAttachment.php
+++ b/src/Plugin/Controller/Sales/Order/PrintAction/DownloadAttachment.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Copyright Youwe. All rights reserved.
+ * https://www.youweagency.com
+ */
+
+declare(strict_types=1);
+
+namespace JcElectronics\ExactOrders\Plugin\Controller\Sales\Order\PrintAction;
+
+use JcElectronics\ExactOrders\Api\AttachmentRepositoryInterface;
+use JcElectronics\ExactOrders\Api\Data\AttachmentInterface;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\UrlInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Controller\AbstractController\OrderLoaderInterface;
+use Magento\Sales\Controller\AbstractController\OrderViewAuthorizationInterface;
+use Magento\Sales\Controller\Order\PrintAction;
+
+class DownloadAttachment
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly OrderViewAuthorizationInterface $orderViewAuthorization,
+        private readonly OrderRepositoryInterface $orderRepository,
+        private readonly AttachmentRepositoryInterface $attachmentRepository,
+        private readonly Filesystem $filesystem,
+        private readonly FileFactory $fileFactory,
+        private readonly ResultFactory $resultFactory
+    ) {
+    }
+
+    public function aroundExecute(
+        PrintAction $subject,
+        callable $proceed
+    ): ResultInterface|ResponseInterface {
+        $orderId    = (int) $this->request->getParam('order_id');
+        $attachment = $this->getAttachmentByOrderId($orderId);
+
+        if (!$attachment instanceof AttachmentInterface) {
+            /** @var Redirect $redirect */
+            $redirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
+            $redirect->setPath(
+                sprintf('sales/order/view/order_id/%d', $orderId)
+            );
+
+            return $redirect;
+        }
+
+        $filePath = sprintf(
+            'substitute_order/%s/%s',
+            $attachment->getEntityTypeId(),
+            $attachment->getFileName()
+        );
+
+        $destination = $this->filesystem
+            ->getDirectoryRead(DirectoryList::VAR_DIR);
+
+        return $this->fileFactory->create(
+            $attachment->getFileName(),
+            base64_decode($destination->readFile($filePath), true) ?: $destination->readFile($filePath),
+            DirectoryList::VAR_DIR
+        );
+    }
+
+    private function getAttachmentByOrderId(int $orderId): ?AttachmentInterface
+    {
+        try {
+            $order = $this->orderRepository->get($orderId);
+        } catch (NoSuchEntityException) {
+            return null;
+        }
+
+        if (!$this->orderViewAuthorization->canView($order)) {
+            return null;
+        }
+
+        try {
+            return $this->attachmentRepository
+                ->getByEntity($orderId, AttachmentInterface::ENTITY_TYPE_ORDER);
+        } catch (NoSuchEntityException) {
+            return null;
+        }
+    }
+}

--- a/src/Plugin/Controller/Sales/Order/PrintInvoice/DownloadAttachment.php
+++ b/src/Plugin/Controller/Sales/Order/PrintInvoice/DownloadAttachment.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * Copyright Youwe. All rights reserved.
+ * https://www.youweagency.com
+ */
+
+declare(strict_types=1);
+
+namespace JcElectronics\ExactOrders\Plugin\Controller\Sales\Order\PrintInvoice;
+
+use JcElectronics\ExactOrders\Api\AttachmentRepositoryInterface;
+use JcElectronics\ExactOrders\Api\Data\AttachmentInterface;
+use Magento\Framework\App\Filesystem\DirectoryList;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\Http\FileFactory;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\UrlInterface;
+use Magento\Sales\Api\InvoiceRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Controller\AbstractController\OrderLoaderInterface;
+use Magento\Sales\Controller\AbstractController\OrderViewAuthorizationInterface;
+use Magento\Sales\Controller\Order\PrintAction;
+use Magento\Sales\Controller\Order\PrintInvoice;
+use Magento\Sales\Model\Order\Invoice;
+
+class DownloadAttachment
+{
+    public function __construct(
+        private readonly RequestInterface $request,
+        private readonly OrderViewAuthorizationInterface $orderViewAuthorization,
+        private readonly InvoiceRepositoryInterface $invoiceRepository,
+        private readonly AttachmentRepositoryInterface $attachmentRepository,
+        private readonly Filesystem $filesystem,
+        private readonly FileFactory $fileFactory,
+        private readonly ResultFactory $resultFactory
+    ) {
+    }
+
+    public function aroundExecute(
+        PrintInvoice $subject,
+        callable $proceed
+    ): ResultInterface|ResponseInterface {
+        $invoiceId  = (int) $this->request->getParam('invoice_id');
+        $attachment = $this->getAttachmentByInvoiceId($invoiceId);
+
+        if (!$attachment instanceof AttachmentInterface) {
+            /** @var Redirect $redirect */
+            $redirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
+            $redirect->setPath(
+                sprintf('sales/order/view/invoice_id/%d', $invoiceId)
+            );
+
+            return $redirect;
+        }
+
+        $filePath = sprintf(
+            'substitute_order/%s/%s',
+            $attachment->getEntityTypeId(),
+            $attachment->getFileName()
+        );
+
+        $destination = $this->filesystem
+            ->getDirectoryRead(DirectoryList::VAR_DIR);
+
+        return $this->fileFactory->create(
+            $attachment->getFileName(),
+            base64_decode($destination->readFile($filePath), true) ?: $destination->readFile($filePath),
+            DirectoryList::VAR_DIR
+        );
+    }
+
+    private function getAttachmentByInvoiceId(int $invoiceId): ?AttachmentInterface
+    {
+        try {
+            /** @var Invoice $invoice */
+            $invoice = $this->invoiceRepository->get($invoiceId);
+        } catch (NoSuchEntityException) {
+            return null;
+        }
+
+        if (!$this->orderViewAuthorization->canView($invoice->getOrder())) {
+            return null;
+        }
+
+        try {
+            return $this->attachmentRepository
+                ->getByEntity($invoiceId, AttachmentInterface::ENTITY_TYPE_ORDER);
+        } catch (NoSuchEntityException) {
+            return null;
+        }
+    }
+}

--- a/src/etc/frontend/di.xml
+++ b/src/etc/frontend/di.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © JC-Electronics. All rights reserved.
+ * https://www.jc-electronics.com
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd"
+>
+    <type name="Magento\Sales\Controller\Order\PrintAction">
+        <plugin name="downloadOrderAttachment"
+                type="JcElectronics\ExactOrders\Plugin\Controller\Sales\Order\PrintAction\DownloadAttachment"
+        />
+    </type>
+    <type name="Magento\Sales\Controller\Order\PrintInvoice">
+        <plugin name="downloadInvoiceAttachment"
+                type="JcElectronics\ExactOrders\Plugin\Controller\Sales\Order\PrintInvoice\DownloadAttachment"
+        />
+    </type>
+</config>


### PR DESCRIPTION
The attachments can be displayed on the frontend now, by just overwriting the original "print" function for orders and invoices.

Also the storage of PDF files has been updated to decode the context, because they are now stored with base64 encoded content.