### PR TITLE
Allow null for postcode and customer ID

### DIFF
--- a/src/Api/Data/ExternalOrder/AddressInterface.php
+++ b/src/Api/Data/ExternalOrder/AddressInterface.php
@@ -88,11 +88,11 @@ interface AddressInterface
     public function getPostcode(): ?string;
 
     /**
-     * @param string $postcode
+     * @param string|null $postcode
      *
      * @return self
      */
-    public function setPostcode(string $postcode): self;
+    public function setPostcode(?string $postcode): self;
 
     /**
      * @return string|null

--- a/src/Api/Data/ExternalOrderInterface.php
+++ b/src/Api/Data/ExternalOrderInterface.php
@@ -94,11 +94,11 @@ interface ExternalOrderInterface
     public function getMagentoCustomerId(): string|int|null;
 
     /**
-     * @param string|int $magentoCustomerId
+     * @param string|int|null $magentoCustomerId
      *
      * @return self
      */
-    public function setMagentoCustomerId(string|int $magentoCustomerId): self;
+    public function setMagentoCustomerId(string|int|null $magentoCustomerId): self;
 
     /**
      * @return string|int|null

--- a/src/Model/ExternalOrder.php
+++ b/src/Model/ExternalOrder.php
@@ -72,7 +72,7 @@ class ExternalOrder extends DataObject implements ExternalOrderInterface
         return $this->_getData(self::KEY_MAGENTO_CUSTOMER_ID);
     }
 
-    public function setMagentoCustomerId(string|int $magentoCustomerId): self
+    public function setMagentoCustomerId(string|int|null $magentoCustomerId): self
     {
         $this->setData(self::KEY_MAGENTO_CUSTOMER_ID, $magentoCustomerId);
 

--- a/src/Model/ExternalOrder/Address.php
+++ b/src/Model/ExternalOrder/Address.php
@@ -81,7 +81,7 @@ class Address extends DataObject implements AddressInterface
         return $this->_getData(self::KEY_POSTCODE);
     }
 
-    public function setPostcode(string $postcode): self
+    public function setPostcode(?string $postcode): self
     {
         $this->setData(self::KEY_POSTCODE, $postcode);
 


### PR DESCRIPTION
For some orders (especially older ones) it can happen that the postcode is `null`. It can also happen that the customer ID in Magento is not set (guest order), which should also be possible to export.

These changes have been handled in this update.