### PR TITLE
Fix incorrect attachment check for existing orders

### DIFF
--- a/src/Api/AttachmentRepositoryInterface.php
+++ b/src/Api/AttachmentRepositoryInterface.php
@@ -23,5 +23,7 @@ interface AttachmentRepositoryInterface
 
     public function getByEntity(int $entityId, string $entityType): AttachmentInterface;
 
+    public function getByAttachmentName(int $entityId, string $entityType, string $fileName): AttachmentInterface;
+
     public function getList(SearchCriteriaInterface $searchCriteria): SearchResultsInterface;
 }

--- a/src/Controller/Attachment/View.php
+++ b/src/Controller/Attachment/View.php
@@ -102,7 +102,7 @@ class View implements HttpGetActionInterface
         }
 
         if (!$isCompanyOrder) {
-            return $order->getCustomerId() === $customerId;
+            return (int) $order->getCustomerId() === (int) $customerId;
         }
 
         $customer                  = $this->customerRepository->getById($customerId);

--- a/src/Modifiers/Invoice/AddInvoiceAttachments.php
+++ b/src/Modifiers/Invoice/AddInvoiceAttachments.php
@@ -39,9 +39,10 @@ class AddInvoiceAttachments extends AbstractModifier
             array_map(
                 function ($attachment) use ($result) {
                     try {
-                        $orderAttachment = $this->attachmentRepository->getByEntity(
+                        $orderAttachment = $this->attachmentRepository->getByAttachmentName(
                             (int) $result->getEntityId(),
-                            AttachmentInterface::ENTITY_TYPE_INVOICE
+                            AttachmentInterface::ENTITY_TYPE_INVOICE,
+                            $attachment->getName()
                         );
                     } catch (NoSuchEntityException) {
                         /** @var AttachmentInterface $orderAttachment */

--- a/src/Modifiers/Order/AddOrderAttachments.php
+++ b/src/Modifiers/Order/AddOrderAttachments.php
@@ -48,9 +48,10 @@ class AddOrderAttachments extends AbstractModifier
             array_map(
                 function ($attachment) use ($result) {
                     try {
-                        $orderAttachment = $this->attachmentRepository->getByEntity(
+                        $orderAttachment = $this->attachmentRepository->getByAttachmentName(
                             (int) $result->getEntityId(),
-                            AttachmentInterface::ENTITY_TYPE_ORDER
+                            AttachmentInterface::ENTITY_TYPE_ORDER,
+                            $attachment->getName()
                         );
                     } catch (NoSuchEntityException) {
                         /** @var AttachmentInterface $orderAttachment */


### PR DESCRIPTION
If an order already had at least one attachment, new attachments were never added because of an incorrect check (only on entity ID and entity type).

To fix this, an updated check has been added that also contains the attachment's file name. If a file name is changed, it will always be treated as a new attachment.